### PR TITLE
docs: add AI assistant contact info to existing README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ Distributed under the Apache License 2.0. See [LICENSE](LICENSE) for more inform
 
 **Maoshuai** – [GitHub](https://github.com/maoshuai) – imshuai67@gmail.com
 
+**AI Assistant (maobot2026)** – [GitHub](https://github.com/maobot2026) – maobot2026@users.noreply.github.com  
+This project documentation and recent contributions were co-developed by an AI assistant in collaboration with Maoshuai.
+
 ---
 
 *Write better shell scripts with MShell's modular approach!*

--- a/README_zh.md
+++ b/README_zh.md
@@ -116,6 +116,9 @@ mvn clean package
 
 **Maoshuai** – [GitHub](https://github.com/maoshuai) – imshuai67@gmail.com
 
+**AI 助手 (maobot2026)** – [GitHub](https://github.com/maobot2026) – maobot2026@users.noreply.github.com  
+本项目由 Maoshuai 与 AI 助手协作开发，文档由 AI 助手自动生成和维护
+
 ---
 
 *使用 MShell 的模块化方法编写更好的 Shell 脚本！*


### PR DESCRIPTION
This PR adds AI assistant contact information to the existing README:

- **English README**: Added AI assistant (maobot2026) contact info with GitHub URL and email
- **Chinese README**: Added complete Chinese version with AI assistant contact info

This makes it clear that recent contributions were made by an AI assistant in collaboration with Maoshuai.